### PR TITLE
feat(css): Add missing `rect()` and `xywh()` functions

### DIFF
--- a/css/functions.json
+++ b/css/functions.json
@@ -517,6 +517,14 @@
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ray"
   },
+  "rect()": {
+    "syntax": "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )",
+    "groups": [
+      "CSS Shapes"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/rect"
+  },
   "rem()": {
     "syntax": "rem( <calc-sum>, <calc-sum> )",
     "groups": [
@@ -818,5 +826,13 @@
     ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline/view"
+  },
+  "xywh()": {
+    "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )",
+    "groups": [
+      "CSS Shapes"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/basic-shape/xywh"
   }
 }

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -734,6 +734,9 @@
   "relative-size": {
     "syntax": "larger | smaller"
   },
+  "rect()": {
+    "syntax": "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )"
+  },
   "rem()": {
     "syntax": "rem( <calc-sum>, <calc-sum> )"
   },
@@ -1000,6 +1003,9 @@
   },
   "wq-name": {
     "syntax": "<ns-prefix>? <ident-token>"
+  },
+  "xywh()": {
+    "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
   },
   "xyz": {
     "syntax": "xyz | xyz-d50 | xyz-d65"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
