### PR TITLE
chore(css): Add CSS Anchor Positioning group

### DIFF
--- a/css/at-rules.json
+++ b/css/at-rules.json
@@ -456,7 +456,7 @@
       "CSSPositionTryRule"
     ],
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@position-try"

--- a/css/definitions.json
+++ b/css/definitions.json
@@ -4,6 +4,7 @@
       "Basic Selectors",
       "Combinators",
       "Compositing and Blending",
+      "CSS Anchor Positioning",
       "CSS Angles",
       "CSS Animations",
       "CSS Backgrounds and Borders",

--- a/css/functions.json
+++ b/css/functions.json
@@ -20,7 +20,7 @@
   "anchor()": {
     "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/anchor"
@@ -28,7 +28,7 @@
   "anchor-size()": {
     "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "status": "experimental",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/anchor-size"

--- a/css/properties.json
+++ b/css/properties.json
@@ -1743,7 +1743,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "initial": "none",
     "appliesto": "allElementsThatGenerateAPrincipalBox",
@@ -1759,7 +1759,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "initial": "none",
     "appliesto": "allElements",
@@ -8402,7 +8402,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "initial": "auto",
     "appliesto": "absolutelyPositionedElements",
@@ -8418,7 +8418,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "initial": "none",
     "appliesto": "positionedElementsWithADefaultAnchorElement",
@@ -8440,7 +8440,7 @@
       "position-try-order"
     ],
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "initial": [
       "position-try-fallbacks",
@@ -8462,7 +8462,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "initial": "none",
     "appliesto": "absolutelyPositionedElements",
@@ -8478,7 +8478,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "initial": "normal",
     "appliesto": "absolutelyPositionedElements",
@@ -8494,7 +8494,7 @@
     "animationType": "discrete",
     "percentages": "no",
     "groups": [
-      "CSS Positioning"
+      "CSS Anchor Positioning"
     ],
     "initial": "anchors-visible",
     "appliesto": "absolutelyPositionedElements",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在CSS文档中新增了“CSS Anchor Positioning”分组，丰富了CSS分类体系。

- **重构**
  - 将多个CSS规则、函数及属性的分组名称从“CSS Positioning”更新为“CSS Anchor Positioning”，以提高分类的准确性和清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->