### PR TITLE
feat(css): Update syntax for `an+b` type

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -496,7 +496,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:not"
   },
   ":nth-child()": {
-    "syntax": ":nth-child( <nth> [ of <complex-selector-list> ]? )",
+    "syntax": ":nth-child( <an+b> [ of <complex-selector-list> ]? )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -505,7 +505,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-child"
   },
   ":nth-last-child()": {
-    "syntax": ":nth-last-child( <nth> [ of <complex-selector-list> ]? )",
+    "syntax": ":nth-last-child( <an+b> [ of <complex-selector-list> ]? )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -514,7 +514,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-child"
   },
   ":nth-last-of-type()": {
-    "syntax": ":nth-last-of-type( <nth> )",
+    "syntax": ":nth-last-of-type( <an+b> )",
     "groups": [
       "Pseudo-classes",
       "Selectors"
@@ -523,7 +523,7 @@
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-of-type"
   },
   ":nth-of-type()": {
-    "syntax": ":nth-of-type( <nth> )",
+    "syntax": ":nth-of-type( <an+b> )",
     "groups": [
       "Pseudo-classes",
       "Selectors"

--- a/css/syntaxes.json
+++ b/css/syntaxes.json
@@ -11,6 +11,9 @@
   "alpha-value": {
     "syntax": "<number> | <percentage>"
   },
+  "an+b": {
+    "syntax": "odd | even | <integer> | <n-dimension> | '+'?† n | -n | <ndashdigit-dimension> | '+'?† <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'?† n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'?† n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'?† n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+  },
   "anchor()": {
     "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )"
   },
@@ -263,6 +266,9 @@
   "dasharray": {
     "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
   },
+  "dashndashdigit-ident": {
+    "syntax": "<ident-token>"
+  },
   "deprecated-system-color": {
     "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
   },
@@ -421,6 +427,9 @@
   },
   "id-selector": {
     "syntax": "<hash-token>"
+  },
+  "integer": {
+    "syntax": "<number-token>"
   },
   "image": {
     "syntax": "<url> | <image()> | <image-set()> | <element()> | <paint()> | <cross-fade()> | <gradient>"
@@ -587,6 +596,18 @@
   "mod()": {
     "syntax": "mod( <calc-sum>, <calc-sum> )"
   },
+  "n-dimension": {
+    "syntax": "<dimension-token>"
+  },
+  "ndash-dimension": {
+    "syntax": "<dimension-token>"
+  },
+  "ndashdigit-dimension": {
+    "syntax": "<dimension-token>"
+  },
+  "ndashdigit-ident": {
+    "syntax": "<ident-token>"
+  },
   "name-repeat": {
     "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+ )"
   },
@@ -598,9 +619,6 @@
   },
   "ns-prefix": {
     "syntax": "[ <ident-token> | '*' ]? '|'"
-  },
-  "nth": {
-    "syntax": "<an-plus-b> | even | odd"
   },
   "number-percentage": {
     "syntax": "<number> | <percentage>"
@@ -838,6 +856,12 @@
   },
   "sign()": {
     "syntax": "sign( <calc-sum> )"
+  },
+  "signed-integer": {
+    "syntax": "<number-token>"
+  },
+  "signless-integer": {
+    "syntax": "<number-token>"
   },
   "sin()": {
     "syntax": "sin( <calc-sum> )"

--- a/css/types.json
+++ b/css/types.json
@@ -1,10 +1,4 @@
 {
-  "an-plus-b": {
-    "groups": [
-      "Selectors"
-    ],
-    "status": "standard"
-  },
   "angle": {
     "groups": [
       "CSS Types"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化了 CSS 选择器伪类（如 nth-child、nth-of-type 等）的表达方式，使其更加符合最新标准。

- **Chores**
  - 扩展了 CSS 语法规则，新增对复杂数值、维度和标识符格式的支持，同时清理了旧版配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->