### PR TITLE
feat(css): Update group definitions for CSS View Transitions

### DIFF
--- a/css/selectors.json
+++ b/css/selectors.json
@@ -129,7 +129,8 @@
     "syntax": ":active-view-transition",
     "groups": [
       "Pseudo-classes",
-      "Selectors"
+      "Selectors",
+      "CSS View Transitions"
     ],
     "status": "standard"
   },
@@ -137,7 +138,8 @@
     "syntax": ":active-view-transition-type( <custom-ident># )",
     "groups": [
       "Pseudo-classes",
-      "Selectors"
+      "Selectors",
+      "CSS View Transitions"
     ],
     "status": "standard"
   },
@@ -1179,7 +1181,8 @@
     "syntax": "::view-transition",
     "groups": [
       "Pseudo-elements",
-      "Selectors"
+      "Selectors",
+      "CSS View Transitions"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition"
@@ -1188,7 +1191,8 @@
     "syntax": "::view-transition-group([ '*' | <custom-ident> ])",
     "groups": [
       "Pseudo-elements",
-      "Selectors"
+      "Selectors",
+      "CSS View Transitions"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-group"
@@ -1197,7 +1201,8 @@
     "syntax": "::view-transition-image-pair([ '*' | <custom-ident> ])",
     "groups": [
       "Pseudo-elements",
-      "Selectors"
+      "Selectors",
+      "CSS View Transitions"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-image-pair"
@@ -1206,7 +1211,8 @@
     "syntax": "::view-transition-new([ '*' | <custom-ident> ])",
     "groups": [
       "Pseudo-elements",
-      "Selectors"
+      "Selectors",
+      "CSS View Transitions"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-new"
@@ -1215,7 +1221,8 @@
     "syntax": "::view-transition-old([ '*' | <custom-ident> ])",
     "groups": [
       "Pseudo-elements",
-      "Selectors"
+      "Selectors",
+      "CSS View Transitions"
     ],
     "status": "standard",
     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-old"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

<!-- Commits need to adhere to conventional commits and only `fix:` and `feat:` commits are added to the release notes. -->
<!-- https://www.conventionalcommits.org/en/v1.0.0/#examples -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 为页面过渡动画的样式设置新增了更明确的分组标签，从而优化了样式管理和分类。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->